### PR TITLE
relocate logging interface to the reusable library location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # studio-go-runner
 
-Version: <repo-version>0.9.5</repo-version>
+Version: <repo-version>0.9.6-feature-189-logger-availability-1gggUK</repo-version>
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/leaf-ai/studio-go-runner/blob/master/LICENSE) [![Go Report Card](https://goreportcard.com/badge/leaf-ai/studio-go-runner)](https://goreportcard.com/report/leaf-ai/studio-go-runner)[![DepShield Badge](https://depshield.sonatype.org/badges/leaf-ai/studio-go-runner/depshield.svg)](https://depshield.github.io)
 

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/leaf-ai/studio-go-runner/internal/runner"
+	"github.com/leaf-ai/studio-go-runner/pkg/studio"
 
 	"github.com/davecgh/go-spew/spew"
 
@@ -42,7 +43,7 @@ var (
 	buildTime string
 	gitHash   string
 
-	logger = runner.NewLogger("runner")
+	logger = studio.NewLogger("runner")
 
 	cfgNamespace = flag.String("k8s-namespace", "default", "The namespace that is being used for our configuration")
 	cfgConfigMap = flag.String("k8s-configmap", "studioml-go-runner", "The name of the Kubernetes ConfigMap where our configuration can be found")

--- a/internal/runner/cuda_test.go
+++ b/internal/runner/cuda_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/karlmutch/errors"
 
 	nvml "github.com/karlmutch/go-nvml"
+
+	"github.com/leaf-ai/studio-go-runner/pkg/studio"
 )
 
 var (
@@ -53,7 +55,7 @@ func readIni(fn string) (items map[string]string, err errors.Error) {
 // TestCUDAActive checks that at least one GPU is available before any other GPU tests are used
 //
 func TestCUDAActive(t *testing.T) {
-	logger := NewLogger("cuda_active_test")
+	logger := studio.NewLogger("cuda_active_test")
 	defer logger.Warn("completed")
 
 	if !*UseGPU {

--- a/internal/runner/k8s_test.go
+++ b/internal/runner/k8s_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/leaf-ai/studio-go-runner/internal/types"
+	"github.com/leaf-ai/studio-go-runner/pkg/studio"
 
 	"github.com/ericchiang/k8s"
 	core "github.com/ericchiang/k8s/apis/core/v1"
@@ -23,7 +24,7 @@ import (
 // changes to a configmap.
 //
 func TestK8sConfigUnit(t *testing.T) {
-	logger := NewLogger("k8s_configmap_test")
+	logger := studio.NewLogger("k8s_configmap_test")
 
 	if !*useK8s {
 		t.Skip("no Kubernetes cluster present for testing")

--- a/pkg/studio/log.go
+++ b/pkg/studio/log.go
@@ -1,7 +1,7 @@
-package runner
+package studio
 
 // This file contains the implementation of a logger that adorns the logxi package with
-// some common information not normally supplied by the generic code
+// some common information not by default supplied by the generic code
 
 import (
 	"os"


### PR DESCRIPTION
Logger interface relocation to make it reusable by external leaf packages

### Which issue(s) does this PR fix?

fixes #189 