### PR TITLE
CUDA 10 Support and nvidia driver upgrades

### DIFF
--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -8,9 +8,11 @@ ENV LANG C.UTF-8
 
 ENV CUDA_8_DEB "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1604-8-0-local-ga2_8.0.61-1_amd64-deb"
 ENV CUDA_9_DEB "https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cuda-repo-ubuntu1604-9-0-local_9.0.176-1_amd64-deb"
-ENV CUDA_PACKAGE_VERSION 9-0
-ENV CUDA_FILESYS_VERSION 9.0
-ENV NVIDIA_VERSION 384
+ENV CUDA_10_DEB "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.0.130-1_amd64.deb"
+
+ENV CUDA_PACKAGE_VERSION 10-0
+ENV CUDA_FILESYS_VERSION 10.0
+ENV NVIDIA_VERSION 418
 
 RUN apt-get -y update && \
     apt-get -y upgrade && \
@@ -22,16 +24,16 @@ RUN apt-get -y update && \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y --no-install-recommends keyboard-configuration ca-certificates apt-transport-https gnupg-curl
 
-RUN cd /tmp && \
-    wget -q -O /tmp/cuda.deb ${CUDA_9_DEB} && \
+RUN mkdir /usr/lib/nvidia && \
+    cd /tmp && \
+    apt-get install -y freeglut3 freeglut3-dev libxi-dev libxmu-dev && \
+    apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub && \
+    wget -q -O /tmp/cuda.deb ${CUDA_10_DEB} && \
     dpkg -i /tmp/cuda.deb && \
-    apt-key add /var/cuda-repo-${CUDA_PACKAGE_VERSION}-local/7fa2af80.pub && \
     apt-get -y update
 
 RUN apt-get -y install --no-install-recommends nvidia-cuda-dev && \
     apt-get -y install --no-install-recommends cuda-nvml-dev-${CUDA_PACKAGE_VERSION} && \
-    apt-get -y install --no-install-recommends libcuinj64-7.5 && \
-    rm /tmp/cuda*.deb && \
     apt-get clean
 
     #wget --quiet -O /tmp/cuda_9.deb ${CUDA_9_DEB} && \
@@ -42,9 +44,12 @@ RUN apt-get -y install --no-install-recommends nvidia-cuda-dev && \
     #rm /tmp/cuda*.deb
 
 RUN \
+    ls /usr/lib | grep nvidia && \
     ln -s /usr/local/cuda-${CUDA_FILESYS_VERSION} /usr/local/cuda && \
     ln -s /usr/local/cuda/targets/x86_64-linux/include /usr/local/cuda/include && \
     ln -s /usr/lib/nvidia-${NVIDIA_VERSION} /usr/lib/nvidia && \
+    apt-get -y install --no-install-recommends libcuinj64-7.5 && \
+    rm /tmp/cuda*.deb && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
     apt-get clean
@@ -85,6 +90,15 @@ RUN apt-get install -y --no-install-recommends \
         libnccl2=2.2.13-1+cuda9.0 && \
     apt-mark hold libnccl2
 
+RUN apt-get install -y --no-install-recommends \
+        cuda-cudart-10-0=10.0.130-1 \
+        cuda-cufft-10-0 \
+        cuda-curand-10-0 \
+        cuda-cusolver-10-0 \
+        cuda-cusparse-10-0 \
+        cuda-libraries-10-0=10.0.130-1 \
+        cuda-cublas-10-0=10.0.130-1
+
 RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
     echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
@@ -94,14 +108,14 @@ ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
-ENV NVIDIA_REQUIRE_CUDA "cuda>=9.0"
+ENV NVIDIA_REQUIRE_CUDA "cuda>=10.0"
 
 # Pick up some TF dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         libcudnn5=5.1.10-1+cuda8.0 \
         libcudnn6=6.0.21-1+cuda8.0 \
-        libcudnn7 \
+        libcudnn7=7.5.0.56-1+cuda10.0 \
         libnccl2=2.2.13-1+cuda9.0 \
         libhdf5-serial-dev \
         libpng12-dev \
@@ -115,13 +129,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN apt-get update && \
     apt-get autoremove && \
-    apt-get install -y python python-pip python3 python3-pip python3-dev python-dev git lshw
+    apt-get install -y python python3 python3-dev python-dev python-virtualenv python-pip python3-pip git lshw
 
 RUN \
     apt-get -y install libssl-dev libcurl4-openssl-dev libsm6 libxrender-dev libxext-dev && \
-    pip install tensorflow-gpu==1.12.3 && \
-    pip install tensorflow-gpu==1.13.1 && \
-    pip install tensorflow-gpu==1.14.0 && \
+    pip3 install tensorflow-gpu==1.12.3 && \
+    pip3 install tensorflow-gpu==1.13.1 && \
+    pip3 install tensorflow-gpu==1.14.0 && \
     apt-get clean
 
 # Will be overitten by other images deriving from this base image

--- a/Dockerfile_developer
+++ b/Dockerfile_developer
@@ -6,9 +6,11 @@ ENV LANG C.UTF-8
 
 ENV CUDA_8_DEB "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1604-8-0-local-ga2_8.0.61-1_amd64-deb"
 ENV CUDA_9_DEB "https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cuda-repo-ubuntu1604-9-0-local_9.0.176-1_amd64-deb"
-ENV CUDA_PACKAGE_VERSION 9-0
-ENV CUDA_FILESYS_VERSION 9.0
-ENV NVIDIA_VERSION 384
+ENV CUDA_10_DEB "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.0.130-1_amd64.deb"
+
+ENV CUDA_PACKAGE_VERSION 10-0
+ENV CUDA_FILESYS_VERSION 10.0
+ENV NVIDIA_VERSION 418
 
 RUN apt-get -y update && \
     export DEBIAN_FRONTEND=noninteractive && \
@@ -16,17 +18,17 @@ RUN apt-get -y update && \
     apt-get -y install make git gcc && apt-get clean && \
     apt-get -y upgrade
 
-RUN cd /tmp && \
-    wget -q -O /tmp/cuda.deb ${CUDA_9_DEB} && \
+RUN mkdir /usr/lib/nvidia && \                                                                                                                                                                                   
+    cd /tmp && \                                                                                                                                                                                                 
+    apt-get install -y freeglut3 freeglut3-dev libxi-dev libxmu-dev && \                                                                                                                                         
+    apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub && \                                                                                         
+    wget -q -O /tmp/cuda.deb ${CUDA_10_DEB} && \                                                                                     
     dpkg -i /tmp/cuda.deb && \
-    apt-key add /var/cuda-repo-${CUDA_PACKAGE_VERSION}-local/7fa2af80.pub && \
     apt-get -y update && \
-    apt-get -y install --no-install-recommends libcuinj64-7.5 && \
     apt-get -y clean && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
     apt-get -y install --no-install-recommends nvidia-cuda-dev cuda-nvml-dev-${CUDA_PACKAGE_VERSION} && \
-    rm /tmp/cuda*.deb && \
     apt-get clean
 
     #wget --quiet -O /tmp/cuda_9.deb ${CUDA_9_DEB} && \
@@ -40,6 +42,8 @@ RUN \
     ln -s /usr/local/cuda-${CUDA_FILESYS_VERSION} /usr/local/cuda && \
     ln -s /usr/local/cuda/targets/x86_64-linux/include /usr/local/cuda/include && \
     ln -s /usr/lib/nvidia-${NVIDIA_VERSION} /usr/lib/nvidia && \
+    apt-get -y install --no-install-recommends libcuinj64-7.5 && \
+    rm /tmp/cuda*.deb && \
     apt-get clean && \
     apt-get autoremove
 
@@ -54,7 +58,7 @@ RUN groupadd -f -g ${USER_GROUP_ID} $USER} && \
 USER ${USER}
 WORKDIR /home/${USER}
 
-ENV GO_VERSION 1.11.9
+ENV GO_VERSION 1.11.12
 
 ENV GOPATH=/project
 ENV PATH=$GOPATH/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # studio-go-runner
 
-Version: <repo-version>0.9.17</repo-version>
+Version: <repo-version>0.9.18-feature-226-cuda-10-aaaagkfewrj</repo-version>
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/leaf-ai/studio-go-runner/blob/master/LICENSE) [![Go Report Card](https://goreportcard.com/badge/leaf-ai/studio-go-runner)](https://goreportcard.com/report/leaf-ai/studio-go-runner)
 

--- a/cmd/runner/Dockerfile
+++ b/cmd/runner/Dockerfile
@@ -82,6 +82,8 @@ RUN pip install --upgrade pip setuptools
 #libssl-dev libcurl4-openssl-dev libsm6 libxrender-dev libxext-dev && \
 RUN apt-get -y update && \
     apt-get -y install  && \
+    pip install setuptools && \
+    pip3 install setuptools && \
     pip3 install tensorflow-gpu==1.12.0 && \
     pip3 install tensorflow-gpu==1.13.1 && \
     pip3 install tensorflow-gpu==1.14.0 && \

--- a/cmd/runner/Dockerfile
+++ b/cmd/runner/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && \
     apt-get update && \
     apt-get -y upgrade
 
-
 RUN apt-get install -y --no-install-recommends \
         cuda-nvrtc-8-0=8.0.61-1 \
         cuda-nvgraph-8-0=8.0.61-1 \
@@ -40,6 +39,15 @@ RUN apt-get install -y --no-install-recommends \
         libnccl2=2.2.13-1+cuda9.0 && \
     apt-mark hold libnccl2
 
+RUN apt-get install -y --no-install-recommends \
+        cuda-cudart-10-0=10.0.130-1 \
+        cuda-cufft-10-0 \
+        cuda-curand-10-0 \
+        cuda-cusolver-10-0 \
+        cuda-cusparse-10-0 \
+        cuda-libraries-10-0=10.0.130-1 \
+        cuda-cublas-10-0=10.0.130-1
+
 RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
     echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
@@ -49,7 +57,7 @@ ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
-ENV NVIDIA_REQUIRE_CUDA "cuda>=9.0"
+ENV NVIDIA_REQUIRE_CUDA "cuda>=10.0"
 
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
         pkg-config \
@@ -62,7 +70,7 @@ RUN apt-get install -y --no-install-recommends \
         build-essential \
         libcudnn5=5.1.10-1+cuda8.0 \
         libcudnn6=6.0.21-1+cuda8.0 \
-        libcudnn7=7.6.1.34-1+cuda9.0 \
+        libcudnn7=7.5.0.56-1+cuda10.0 \
         libnccl2=2.2.13-1+cuda9.0 \
         libhdf5-serial-dev \
         libpng12-dev \
@@ -74,8 +82,9 @@ RUN pip install --upgrade pip setuptools
 #libssl-dev libcurl4-openssl-dev libsm6 libxrender-dev libxext-dev && \
 RUN apt-get -y update && \
     apt-get -y install  && \
-    pip install tensorflow-gpu==1.12.0 && \
-    pip install tensorflow-gpu==1.12.3 && \
+    pip3 install tensorflow-gpu==1.12.0 && \
+    pip3 install tensorflow-gpu==1.13.1 && \
+    pip3 install tensorflow-gpu==1.14.0 && \
     python -m pip install virtualenv==15.2.0 --force-reinstall && \
     python3 -m pip install virtualenv==15.2.0 --force-reinstall && \
     apt-get clean

--- a/internal/runner/pythonenv.go
+++ b/internal/runner/pythonenv.go
@@ -137,7 +137,7 @@ func (p *VirtualEnv) Make(alloc *Allocated, e interface{}) (err kv.Error) {
 	// The tensorflow versions 1.5.x and above all support cuda 9 and 1.4.x is cuda 8,
 	// c.f. https://www.tensorflow.org/install/install_sources#tested_source_configurations.
 	// Insert the appropriate version explicitly into the LD_LIBRARY_PATH before other paths
-	cudaDir := "/usr/local/cuda-9.0/lib64"
+	cudaDir := "/usr/local/cuda-10.0/lib64"
 	if strings.HasPrefix(tfVer, "1.4") {
 		cudaDir = "/usr/local/cuda-8.0/lib64"
 	}


### PR DESCRIPTION
fixes #226

nvidia 418 and cuda 10 cuDNN 7.5 support
The minimum version of Tensorflow now supported is 1.12.0