### PR TITLE
move the busyQ into the queue structure, reduce complexity for some functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # studio-go-runner
 
-Version: <repo-version>0.9.26-master-aaaagngsxrt</repo-version>
+Version: <repo-version>0.9.26-master-aaaagngxyzf</repo-version>
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/leaf-ai/studio-go-runner/blob/master/LICENSE) [![Go Report Card](https://goreportcard.com/badge/leaf-ai/studio-go-runner)](https://goreportcard.com/report/leaf-ai/studio-go-runner)
 

--- a/cmd/runner/processor.go
+++ b/cmd/runner/processor.go
@@ -999,7 +999,10 @@ func (p *processor) deployAndRun(ctx context.Context, alloc *runner.Allocated, a
 			termination = "deployAndRun ctx abort"
 		default:
 		}
-		logger.Info(termination, "project_id", p.Request.Config.Database.ProjectId, "experiment_id", p.Request.Experiment.Key)
+
+		ctxProj, _ := FromProjectContext(ctx)
+
+		logger.Info(termination, "project_id", p.Request.Config.Database.ProjectId, "ctx_project_id", ctxProj, "experiment_id", p.Request.Experiment.Key)
 
 		// We should always upload results even in the event of an error to
 		// help give the experimenter some clues as to what might have

--- a/cmd/runner/project.go
+++ b/cmd/runner/project.go
@@ -1,0 +1,29 @@
+// Copyright 2018-2020 (c) Cognizant Digital Business, Evolutionary AI. All rights reserved. Issued under the Apache 2.0 License.
+
+package main
+
+// This file contains a simple project tracking value type that will accompany the
+// contexts that are scoped to servicing a queue within a queue server
+
+import (
+	"context"
+)
+
+type projectContextKey string
+
+type projectType string
+
+var (
+	projectKey = projectContextKey("project")
+)
+
+// NewContext returns a new Context that carries a value for the project associated with the context
+func NewProjectContext(ctx context.Context, proj string) context.Context {
+	return context.WithValue(ctx, projectKey, proj)
+}
+
+// FromContext returns the User value stored in ctx, if any.
+func FromProjectContext(ctx context.Context) (proj string, wasPresent bool) {
+	proj, wasPresent = ctx.Value(projectKey).(string)
+	return proj, wasPresent
+}

--- a/cmd/runner/rabbit.go
+++ b/cmd/runner/rabbit.go
@@ -164,10 +164,18 @@ func serviceRMQ(ctx context.Context, checkInterval time.Duration, connTimeout ti
 				continue
 			}
 
+			// Found rneeds to just have the main queue servers as their keys, individual queues will be treated as subscriptions
+
+			filtered := make(map[string]string, len(found))
+			for k, v := range found {
+				qItems := strings.Split(k, "?")
+				filtered[qItems[0]] = v
+			}
+
 			// found contains a map of keys that have an uncredentialed URL, and the value which is the user name and password for the URL
 			//
 			// The URL path is going to be the vhost and the queue name
-			live.Lifecycle(ctx, found)
+			live.Lifecycle(ctx, filtered)
 		}
 	}
 }

--- a/internal/runner/rmq.go
+++ b/internal/runner/rmq.go
@@ -235,6 +235,9 @@ func (rmq *RabbitMQ) Exists(ctx context.Context, subscription string) (exists bo
 	}()
 
 	if _, errGo = mgmt.GetQueue(vhost, queue); errGo != nil {
+		if response, ok := errGo.(rh.ErrorResponse); ok && response.StatusCode == 404 {
+			return false, nil
+		}
 		return false, kv.Wrap(errGo).With("stack", stack.Trace().TrimRuntime()).With("uri", rmq.mgmt)
 	}
 


### PR DESCRIPTION
fixes #285 

Will require another ticket to move the queue rebalancing into the backoffs cache structure.  This is a shift away from the individual checks of the doWork being driven by channel messages to the backoff structure.