### PR TITLE
Added git_info.go module to always have go-runner buildable.

### DIFF
--- a/cmd/runner/git_info.go
+++ b/cmd/runner/git_info.go
@@ -1,0 +1,7 @@
+package main
+
+// GitCommit is the current git commit ID
+var gitCommit string = "unknown"
+
+// GitBranch is the current git branch name
+var gitBranch string = "unknown"


### PR DESCRIPTION
That simplifies build process for external security scanning/code checks etc.
